### PR TITLE
Avoid linker error when build for Android uses IL2CPP

### DIFF
--- a/Assets/Scripts/TapticEngine.cs
+++ b/Assets/Scripts/TapticEngine.cs
@@ -5,6 +5,7 @@ namespace UnityModule.HapticFeedback
 {
     public static class TapticEngine
     {
+#if UNITY_IOS
         [DllImport("__Internal")]
         private static extern void _Impact(int mode);
 
@@ -13,29 +14,36 @@ namespace UnityModule.HapticFeedback
 
         [DllImport("__Internal")]
         private static extern void _Selection();
+#endif
         
         public static void Impact(TapticImpactType type)
         {
+#if UNITY_IOS
             if (Application.platform == RuntimePlatform.IPhonePlayer)
             {
                 _Impact((int)type);
             }
+#endif
         }
 
         public static void Selection()
         {
+#if UNITY_IOS
             if (Application.platform == RuntimePlatform.IPhonePlayer)
             {
                 _Selection();
             }
+#endif
         }
 
         public static void Notification(TapticNotificationType type)
         {
+#if UNITY_IOS
             if (Application.platform == RuntimePlatform.IPhonePlayer)
             {
                 _Notification((int)type);
             }
+#endif
         }
     }
 }


### PR DESCRIPTION
* `DllImport` affect to Android when uses IL2CPP